### PR TITLE
support special regions

### DIFF
--- a/GCConverter/Form1.cs
+++ b/GCConverter/Form1.cs
@@ -73,6 +73,31 @@ namespace GCConverter
                         btnConvert.Enabled = true;
                         txtStatus.Text = "Selected file is NTSC-J. ";
                     }
+                    //Other possible save files according to https://wiki.dolphin-emu.org/index.php?title=GameIDs
+                    else if (fileContent.Substring(6, 2) == "44" || //Germany
+                        fileContent.Substring(6, 2) == "46" || //France
+                        fileContent.Substring(6, 2) == "48" || //Netherlands
+                        fileContent.Substring(6, 2) == "49" || //Italy
+                        fileContent.Substring(6, 2) == "4B" || //Korea
+                        fileContent.Substring(6, 2) == "4C" || //Japanese PAL Import
+                        fileContent.Substring(6, 2) == "4D" || //American PAL Import
+                        fileContent.Substring(6, 2) == "4E" || //Japanese NTSC Import
+                        fileContent.Substring(6, 2) == "52" || //Russia
+                        fileContent.Substring(6, 2) == "53" || //Spain
+                        fileContent.Substring(6, 2) == "55" || //PAL alternate languages
+                        fileContent.Substring(6, 2) == "56" || //Scandinavia
+                        fileContent.Substring(6, 2) == "57" || //Taiwan - Hong Kong - Macau
+                        fileContent.Substring(6, 2) == "58" || //PAL alternate language - NTSC special release
+                        fileContent.Substring(6, 2) == "59" || //PAL alternate language - NTSC special release
+                        fileContent.Substring(6, 2) == "5A") //PAL alternate language - NTSC special release)
+                    {
+                        rdPAL.Enabled = true;
+                        rdNTSCU.Enabled = true;
+                        rdNTSCJ.Enabled = true;
+                        rdNTSCU.Checked = true;
+                        btnConvert.Enabled = true;
+                        txtStatus.Text = "Selected file has a special region code. ";
+                    }
                     else
                     {
                         rdPAL.Enabled = false;


### PR DESCRIPTION
Extend the file detection to all known GameCube save file regions. See https://wiki.dolphin-emu.org/index.php?title=GameIDs for more information